### PR TITLE
CRM core contact entities are now called crm_core_individual

### DIFF
--- a/src/Plugin/EntityReferenceSelection/CrmContactRngSelection.php
+++ b/src/Plugin/EntityReferenceSelection/CrmContactRngSelection.php
@@ -10,7 +10,7 @@ use Drupal\rng\Plugin\EntityReferenceSelection\RNGSelectionBase;
  * @EntityReferenceSelection(
  *   id = "rng:register:crm_core_contact",
  *   label = @Translation("CRM Core contact selection"),
- *   entity_types = {"crm_core_contact"},
+ *   entity_types = {"crm_core_individual"},
  *   group = "rng_register",
  *   provider = "courier_crm_core_contact",
  *   weight = 10

--- a/src/Plugin/IdentityChannel/CourierEmail/CrmCoreContact.php
+++ b/src/Plugin/IdentityChannel/CourierEmail/CrmCoreContact.php
@@ -14,7 +14,7 @@ use Drupal\courier\Exception\IdentityException;
  *   id = "identity:crm_core_contact:courier_email",
  *   label = @Translation("CRM Core contact to courier_mail"),
  *   channel = "courier_email",
- *   identity = "crm_core_contact",
+ *   identity = "crm_core_individual",
  *   weight = 10
  * )
  */


### PR DESCRIPTION
Fixes that the entity type used does not match the latest changes in CRM Core: https://www.drupal.org/node/2708029
